### PR TITLE
fixing Dockerfiles for running docker images

### DIFF
--- a/blockchain-explorer/Dockerfile
+++ b/blockchain-explorer/Dockerfile
@@ -1,15 +1,17 @@
 ARG  base
 FROM ${base} as builder
 
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 COPY --from=builder /ton/build/blockchain-explorer/blockchain-explorer /usr/local/bin/
-COPY blockchain-explorer/start.sh /
+COPY ./start.sh /
 
 
-RUN apt-get update && apt-get install -y libmicrohttpd12 wget && apt-mark manual libmicrohttpd12 wget &&\
+RUN apt-get update && apt-get install -y libsecp256k1-dev libsodium-dev libmicrohttpd12 wget && apt-mark manual libmicrohttpd12 wget &&\
   apt-get autoremove -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /lib/x86_64-linux-gnu/libsecp256k1.so.1.0.0 /usr/lib/libsecp256k1.so.0
 
 ENTRYPOINT ["/start.sh"]

--- a/ton-full-node/Dockerfile
+++ b/ton-full-node/Dockerfile
@@ -1,9 +1,10 @@
 ARG  base
 FROM ${base} as builder
 
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 RUN mkdir -p /var/ton-work/db/static
+RUN mkdir -p /var/ton-work/db/dht-server
 
 ENV FIFTPATH /usr/local/lib/fift
 
@@ -26,12 +27,14 @@ COPY --from=builder /ton/crypto/smartcont /var/ton-work/contracts
 WORKDIR /var/ton-work/
 
 ADD /scripts/requirements.txt /var/ton-work/requirements.txt
-RUN apt-get update && apt-get install -y gcc libmicrohttpd12 && apt-mark manual libmicrohttpd12 &&\
+RUN apt-get update && apt-get install -y gcc libmicrohttpd12 libsecp256k1-dev libsodium-dev && apt-mark manual libmicrohttpd12 &&\
   PIP_NO_CACHE_DIR=1 pip install -r /var/ton-work/requirements.txt && \
   apt-get remove -y gcc && \
   apt-get autoremove -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /lib/x86_64-linux-gnu/libsecp256k1.so.1.0.0 /usr/lib/libsecp256k1.so.0
 
 ADD ./contracts/gen-zerostate.fif /var/ton-work/contracts
 ADD ./contracts/wallet.fif /var/ton-work/contracts/valik-wallet.fif

--- a/ton-toncenter/Dockerfile
+++ b/ton-toncenter/Dockerfile
@@ -13,18 +13,19 @@ COPY --from=builder /ton/build/tonlib/libtonlibjson.so.0.5 ./pyTON/distlib/linux
 # fix /api/v2
 RUN sed -i 's/\/api\/v2/\//g' ./pyTON/main.py
 
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 WORKDIR ton-http-api
 COPY --from=git ton-http-api ./
 
-RUN apt-get update && apt-get install -y gcc && \
+RUN apt-get update && apt-get install -y gcc libsecp256k1-dev libsodium-dev wget && \
   PIP_NO_CACHE_DIR=1 python3 -m pip install -r ./infrastructure/requirements/main.txt && \
   apt-get remove -y gcc && \
   apt-get autoremove -y && \
-  apt-get install -y wget && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /lib/x86_64-linux-gnu/libsecp256k1.so.1.0.0 /usr/lib/libsecp256k1.so.0
 
 ADD ./entrypoint.sh ./
 


### PR DESCRIPTION
1. The packages libsecp256k1-dev and libsodium-dev are required to run containers, but even after installation the application does not find the required library and I had to make a symlink
2. An applications require the libcrypto.so.1.1.1 library, which is pulled in as a dependency of the libssl1.1.1 package and openssl (1.1.1) . Therefore, the application runs correctly only in the debian bullseye release, where the required versions of these libraries are installed from the beginning. I tried to downgrade the openssl version from 3 to 1.1.1 in a more modern debian release by compiling from source, as well as installing a ready-made package from the debian repository, but in one of the images it was not successful. So the easiest thing to do now is to just use the debian bullseye version.